### PR TITLE
Hide datepicker when tab out of input.

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -1196,6 +1196,7 @@ function oneHandler(e) {
   */
   if (e.__qs_shadow_dom) return
 
+  var keyCode = e.keyCode
   var type = e.type
   var target = e.target
   var classList = target.classList
@@ -1282,6 +1283,9 @@ function oneHandler(e) {
 
     // Hide all other instances.
     hideOtherPickers(instance)
+  } else if (type === 'keydown' && keyCode === 9 && instance) {    
+    // Hide this intance on tab out.
+    hideCal(instance)    
   } else if (type === 'keydown' && instance && !instance.disabled) {
     var overlay = instance.calendar.querySelector('.qs-overlay')
     var overlayShowing = !overlay.classList.contains('qs-hidden')


### PR DESCRIPTION
Restore the behavior introduced in this pull request:
https://github.com/qodesmith/datepicker/pull/2